### PR TITLE
bugfix: throw "expected at least 8 bytes" error only when less than 8 bytes received

### DIFF
--- a/src/datasource/precomputed/backend.ts
+++ b/src/datasource/precomputed/backend.ts
@@ -600,7 +600,7 @@ function parseAnnotations(
   propertySerializer: AnnotationPropertySerializer,
 ): AnnotationGeometryData {
   const dv = new DataView(buffer);
-  if (buffer.byteLength <= 8) throw new Error("Expected at least 8 bytes");
+  if (buffer.byteLength < 8) throw new Error("Expected at least 8 bytes");
   const countLow = dv.getUint32(0, /*littleEndian=*/ true);
   const countHigh = dv.getUint32(4, /*littleEndian=*/ true);
   if (countHigh !== 0) throw new Error("Annotation count too high");


### PR DESCRIPTION
If the buffer is exactly 8 bytes — which is the case for an empty spatial index chunk — then the code would throw an "Expected at least 8 bytes" error, due to the use of a `<=` comparison rather than `<`.

This commit fixes that bug.